### PR TITLE
feat(testing): add public `eu5miner.testing` module + library-side contract tests

### DIFF
--- a/src/eu5miner/testing.py
+++ b/src/eu5miner/testing.py
@@ -1,0 +1,166 @@
+"""Public testing utilities for the EU5Miner ecosystem.
+
+These helpers are intended for use by:
+- The library's own tests (``tests/``)
+- Downstream consumer packages (``eu5miner-gui``, ``eu5miner-mcp``)
+- Anyone writing integration or smoke tests against a synthetic EU5 install
+
+They produce a small, deterministic filesystem layout under the supplied
+``root`` directory. No real EU5 install is required.
+
+Typical use::
+
+    from pathlib import Path
+    from eu5miner.testing import build_synthetic_install
+    from eu5miner.inspection import inspect_install
+
+    def test_my_feature(tmp_path: Path) -> None:
+        install_root = tmp_path / "install"
+        build_synthetic_install(install_root)
+        summary = inspect_install(install_root)
+        assert summary.root == install_root
+
+The contract here is intentionally small and stable: changing the shape of the
+returned ``GameInstall`` or the ``SyntheticCliSmokeSurface`` /
+``SyntheticModWorkflowSurface`` dataclasses is a breaking change and will
+require updating cross-package tests in ``eu5miner-gui`` and ``eu5miner-mcp``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from eu5miner.source import ContentPhase, GameInstall
+
+
+@dataclass(frozen=True)
+class SyntheticCliSmokeSurface:
+    """Minimal synthetic install plus a couple of representative files.
+
+    Useful for CLI smoke tests that need to drive ``eu5miner`` against a
+    known-good layout without a real EU5 install on disk.
+    """
+
+    install: GameInstall
+    install_root: Path
+    gui_relative_path: Path
+    gui_file: Path
+    script_file: Path
+
+
+@dataclass(frozen=True)
+class SyntheticModWorkflowSurface:
+    """Synthetic install with a vanilla file plus a mod root and a content root.
+
+    Used for mod workflow tests: planning and applying an override against a
+    known vanilla file, with a second (later) mod that should be reported as
+    ``blocked`` for one of the intended paths.
+    """
+
+    install: GameInstall
+    install_root: Path
+    vanilla_file: Path
+    target_mod_root: Path
+    later_mod_root: Path
+    content_root: Path
+    override_relative_path: Path
+    blocked_relative_path: Path
+
+
+def build_synthetic_install(install_root: Path) -> GameInstall:
+    """Create an empty synthetic EU5 install layout under ``install_root``.
+
+    The layout matches what ``GameInstall.discover`` expects:
+    ``<install_root>/game/{loading_screen,main_menu,in_game}/`` plus
+    ``<install_root>/game/{dlc,mod}/``. No representative files are written.
+    """
+    game_dir = install_root / "game"
+    dlc_dir = game_dir / "dlc"
+    mod_dir = game_dir / "mod"
+
+    for phase_name in ("loading_screen", "main_menu", "in_game"):
+        (game_dir / phase_name).mkdir(parents=True, exist_ok=True)
+    dlc_dir.mkdir(parents=True, exist_ok=True)
+    mod_dir.mkdir(parents=True, exist_ok=True)
+
+    return GameInstall(
+        root=install_root,
+        game_dir=game_dir,
+        dlc_dir=dlc_dir,
+        mod_dir=mod_dir,
+    )
+
+
+def build_synthetic_cli_smoke_surface(root: Path) -> SyntheticCliSmokeSurface:
+    """Create a synthetic install plus a couple of representative files.
+
+    Writes a minimal ``in_game/gui/smoke.gui`` file inside the install and a
+    standalone script file outside the install, returning the surface needed
+    to drive ``eu5miner`` CLI commands against them.
+    """
+    install_root = root / "install"
+    install = build_synthetic_install(install_root)
+    gui_relative_path = Path("gui") / "smoke.gui"
+    gui_file = install.phase_dir(ContentPhase.IN_GAME) / gui_relative_path
+    script_file = root / "standalone_script.txt"
+
+    _write_file(gui_file, "guiTypes = { widget = { name = smoke_widget } }\n")
+    _write_file(script_file, "smoke_trigger = { always = yes }\n")
+
+    return SyntheticCliSmokeSurface(
+        install=install,
+        install_root=install_root,
+        gui_relative_path=gui_relative_path,
+        gui_file=gui_file,
+        script_file=script_file,
+    )
+
+
+def build_synthetic_mod_workflow_surface(root: Path) -> SyntheticModWorkflowSurface:
+    """Create a synthetic install with a vanilla file plus a mod/content layout.
+
+    The vanilla file lives at ``<install>/in_game/common/buildings/a.txt`` and
+    is intended to be overridden by ``content_root`` when planning a mod update.
+    A second, later mod (``later_mod_root``) shadows one path, so the planner
+    should report that path as ``blocked`` rather than ``override``.
+    """
+    install_root = root / "install"
+    install = build_synthetic_install(install_root)
+    target_mod_root = root / "my_mod"
+    later_mod_root = root / "late_mod"
+    content_root = root / "content_root"
+    override_relative_path = Path("common") / "buildings" / "a.txt"
+    blocked_relative_path = Path("common") / "buildings" / "blocked.txt"
+
+    vanilla_file = install.phase_dir(ContentPhase.IN_GAME) / override_relative_path
+    _write_file(vanilla_file, "vanilla\n")
+    _write_file(later_mod_root / "in_game" / blocked_relative_path, "late\n")
+
+    _write_file(content_root / override_relative_path, "override = yes\n")
+    _write_file(content_root / blocked_relative_path, "blocked = yes\n")
+
+    return SyntheticModWorkflowSurface(
+        install=install,
+        install_root=install_root,
+        vanilla_file=vanilla_file,
+        target_mod_root=target_mod_root,
+        later_mod_root=later_mod_root,
+        content_root=content_root,
+        override_relative_path=override_relative_path,
+        blocked_relative_path=blocked_relative_path,
+    )
+
+
+def _write_file(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+__all__ = [
+    "SyntheticCliSmokeSurface",
+    "SyntheticModWorkflowSurface",
+    "build_synthetic_install",
+    "build_synthetic_cli_smoke_surface",
+    "build_synthetic_mod_workflow_surface",
+]

--- a/tests/integration_support.py
+++ b/tests/integration_support.py
@@ -1,97 +1,26 @@
+"""Internal re-export shim for the synthetic-install helpers.
+
+The public home for these helpers is now ``eu5miner.testing``. This module
+exists so existing internal tests can keep importing from
+``tests.integration_support`` without churn. New code should import directly
+from ``eu5miner.testing`` so the helpers can be reused from
+``eu5miner-gui`` and ``eu5miner-mcp`` without path manipulation.
+"""
+
 from __future__ import annotations
 
-from dataclasses import dataclass
-from pathlib import Path
+from eu5miner.testing import (
+    SyntheticCliSmokeSurface,
+    SyntheticModWorkflowSurface,
+    build_synthetic_cli_smoke_surface,
+    build_synthetic_install,
+    build_synthetic_mod_workflow_surface,
+)
 
-from eu5miner.source import ContentPhase, GameInstall
-
-
-@dataclass(frozen=True)
-class SyntheticCliSmokeSurface:
-    install: GameInstall
-    install_root: Path
-    gui_relative_path: Path
-    gui_file: Path
-    script_file: Path
-
-
-@dataclass(frozen=True)
-class SyntheticModWorkflowSurface:
-    install: GameInstall
-    install_root: Path
-    vanilla_file: Path
-    target_mod_root: Path
-    later_mod_root: Path
-    content_root: Path
-    override_relative_path: Path
-    blocked_relative_path: Path
-
-
-def build_synthetic_install(install_root: Path) -> GameInstall:
-    game_dir = install_root / "game"
-    dlc_dir = game_dir / "dlc"
-    mod_dir = game_dir / "mod"
-
-    for phase_name in ("loading_screen", "main_menu", "in_game"):
-        (game_dir / phase_name).mkdir(parents=True, exist_ok=True)
-    dlc_dir.mkdir(parents=True, exist_ok=True)
-    mod_dir.mkdir(parents=True, exist_ok=True)
-
-    return GameInstall(
-        root=install_root,
-        game_dir=game_dir,
-        dlc_dir=dlc_dir,
-        mod_dir=mod_dir,
-    )
-
-
-def build_synthetic_cli_smoke_surface(root: Path) -> SyntheticCliSmokeSurface:
-    install_root = root / "install"
-    install = build_synthetic_install(install_root)
-    gui_relative_path = Path("gui") / "smoke.gui"
-    gui_file = install.phase_dir(ContentPhase.IN_GAME) / gui_relative_path
-    script_file = root / "standalone_script.txt"
-
-    _write_file(gui_file, "guiTypes = { widget = { name = smoke_widget } }\n")
-    _write_file(script_file, "smoke_trigger = { always = yes }\n")
-
-    return SyntheticCliSmokeSurface(
-        install=install,
-        install_root=install_root,
-        gui_relative_path=gui_relative_path,
-        gui_file=gui_file,
-        script_file=script_file,
-    )
-
-
-def build_synthetic_mod_workflow_surface(root: Path) -> SyntheticModWorkflowSurface:
-    install_root = root / "install"
-    install = build_synthetic_install(install_root)
-    target_mod_root = root / "my_mod"
-    later_mod_root = root / "late_mod"
-    content_root = root / "content_root"
-    override_relative_path = Path("common") / "buildings" / "a.txt"
-    blocked_relative_path = Path("common") / "buildings" / "blocked.txt"
-
-    vanilla_file = install.phase_dir(ContentPhase.IN_GAME) / override_relative_path
-    _write_file(vanilla_file, "vanilla\n")
-    _write_file(later_mod_root / "in_game" / blocked_relative_path, "late\n")
-
-    _write_file(content_root / override_relative_path, "override = yes\n")
-    _write_file(content_root / blocked_relative_path, "blocked = yes\n")
-
-    return SyntheticModWorkflowSurface(
-        install=install,
-        install_root=install_root,
-        vanilla_file=vanilla_file,
-        target_mod_root=target_mod_root,
-        later_mod_root=later_mod_root,
-        content_root=content_root,
-        override_relative_path=override_relative_path,
-        blocked_relative_path=blocked_relative_path,
-    )
-
-
-def _write_file(path: Path, text: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text, encoding="utf-8")
+__all__ = [
+    "SyntheticCliSmokeSurface",
+    "SyntheticModWorkflowSurface",
+    "build_synthetic_cli_smoke_surface",
+    "build_synthetic_install",
+    "build_synthetic_mod_workflow_surface",
+]

--- a/tests/test_inspection_contract.py
+++ b/tests/test_inspection_contract.py
@@ -1,90 +1,216 @@
+"""Contract tests for the ``eu5miner.inspection`` facade.
+
+These tests pin the public shape of the inspection facade — the same surface
+that ``eu5miner-gui`` (its ``DesktopController``) and ``eu5miner-mcp`` (its
+``tools/entities.py``, ``tools/systems.py``, ``tools/install.py``) consume.
+
+If a field is renamed, removed, or its type changes, these tests will fail.
+The point is to catch breaking library changes BEFORE they cascade into the
+GUI or MCP repos, which is exactly the cross-package pain these tests exist
+to prevent.
+
+What this covers:
+- Public function set of the facade (the methods GUI/MCP can call)
+- Dataclass field names and types for every returned type
+- End-to-end behavior of ``inspect_install`` on a synthetic install
+- Compatibility of the ``SystemInfo`` / ``EntitySystemInfo`` enums that
+  drive the GUI's sidebar and the MCP's tool schema
+
+What this deliberately does NOT cover:
+- The internal ``eu5miner.domains.*`` parsers (those have their own
+  dedicated tests in ``tests/domains/``)
+- The mod workflow facade (``eu5miner.mods``) — covered separately
+  by ``tests/test_cli_mod_workflow_contract.py``
+"""
+
 from __future__ import annotations
 
-import eu5miner
-import eu5miner.inspection as inspection_api
-from eu5miner.inspection import list_entity_systems, list_supported_systems
+from dataclasses import fields, is_dataclass
+from pathlib import Path
+from typing import get_type_hints
 
-EXPECTED_SUPPORTED_SYSTEMS = (
-    (
-        "economy",
-        "Goods, prices, production, demand, and market helper coverage.",
-    ),
-    (
-        "diplomacy",
-        "War-flow, diplomacy graph, and unit-family coverage.",
-    ),
-    (
-        "government",
-        "Government, law, estate, parliament, and institution coverage.",
-    ),
-    (
-        "religion",
-        "Religion, holy-site, and religious helper coverage.",
-    ),
-    (
-        "interface",
-        "Localization, GUI, and frontend-content coverage.",
-    ),
-    (
-        "map",
-        "Map text, map CSV, and linked setup-location coverage.",
-    ),
-)
+import pytest
 
-EXPECTED_BROWSABLE_SYSTEMS = (
-    (
-        "economy",
-        "Browse goods definitions with market-facing fields and related good links.",
-        "good",
-    ),
-    (
-        "diplomacy",
-        "Browse casus belli definitions with linked wargoals, peace treaties, "
-        "and country interactions.",
-        "casus_belli",
-    ),
-    (
-        "government",
-        "Browse government types with linked reforms, laws, and default estates.",
-        "government_type",
-    ),
-    (
-        "religion",
-        "Browse religions with linked aspects, factions, focuses, schools, "
-        "figures, and holy sites.",
-        "religion",
-    ),
-    (
-        "map",
-        "Browse linked locations merged from map hierarchy and main-menu setup data.",
-        "location",
-    ),
+import eu5miner.inspection as inspection
+from eu5miner.testing import build_synthetic_install
+
+# ----- Public function set ----------------------------------------------------
+
+
+# These are the symbols the GUI and MCP are known to depend on. Any rename
+# here is a breaking change for at least one of the consumer packages.
+REQUIRED_PUBLIC_FUNCTIONS = frozenset(
+    {
+        "inspect_install",
+        "summarize_install",
+        "format_install_summary",
+        "list_supported_systems",
+        "list_entity_systems",
+        "list_system_entities",
+        "get_system_report",
+        "format_system_report",
+        "get_system_entity",
+        "invalidate_system_entity_cache",
+    }
 )
 
 
-def test_supported_systems_match_stabilized_order_and_descriptions() -> None:
-    systems = tuple((system.name, system.description) for system in list_supported_systems())
-
-    assert systems == EXPECTED_SUPPORTED_SYSTEMS
-
-
-def test_browsable_entity_systems_match_stabilized_subset_order_and_descriptions() -> None:
-    systems = tuple(
-        (system.name, system.description, system.primary_entity_kind)
-        for system in list_entity_systems()
-    )
-
-    assert systems == EXPECTED_BROWSABLE_SYSTEMS
-    assert tuple(system[0] for system in EXPECTED_BROWSABLE_SYSTEMS) == tuple(
-        name for name, _description in EXPECTED_SUPPORTED_SYSTEMS if name != "interface"
+def test_required_public_functions_exist() -> None:
+    """The facade must keep exporting the functions the consumers depend on."""
+    missing = sorted(REQUIRED_PUBLIC_FUNCTIONS - set(dir(inspection)))
+    assert not missing, (
+        f"Missing required public functions on eu5miner.inspection: {missing}. "
+        "If you renamed one, also update eu5miner-gui and eu5miner-mcp."
     )
 
 
-def test_root_package_keeps_inspection_facade_as_an_explicit_import_boundary() -> None:
-    root_exports = set(eu5miner.__all__)
-    inspection_exports = set(inspection_api.__all__)
+# ----- Dataclass field shape --------------------------------------------------
 
-    assert inspection_exports.isdisjoint(root_exports)
-    for name in inspection_api.__all__:
-        assert hasattr(inspection_api, name)
-        assert not hasattr(eu5miner, name)
+
+# Dataclasses the GUI and MCP construct/persist. The field shapes here are
+# what their adapters, controllers, and serializers assume.
+REQUIRED_DATACLASSES = {
+    "SystemInfo": ("name", "description"),
+    "EntitySystemInfo": ("name", "description", "primary_entity_kind"),
+    "EntitySummary": ("system", "entity_kind", "name", "group", "description"),
+    "EntityField": ("name", "value"),
+    "EntityReference": ("role", "system", "entity_kind", "target_name"),
+    "EntityDetail": ("summary", "fields", "references"),
+    "InstallPhaseRoot": ("phase", "path"),
+    "InstallSourceSummary": (
+        "name",
+        "kind",
+        "root",
+        "priority",
+        "replace_paths",
+    ),
+    "InstallSummary": (
+        "root",
+        "game_dir",
+        "dlc_dir",
+        "mod_dir",
+        "phase_roots",
+        "sources",
+    ),
+    "SystemReport": (
+        "name",
+        "description",
+        "representative_keys",
+        "summary_lines",
+    ),
+}
+
+
+@pytest.mark.parametrize("class_name,expected_fields", sorted(REQUIRED_DATACLASSES.items()))
+def test_required_dataclass_field_shape(class_name: str, expected_fields: tuple[str, ...]) -> None:
+    """Each public dataclass must keep the field set consumers rely on."""
+    obj = getattr(inspection, class_name, None)
+    assert obj is not None, f"Missing public type eu5miner.inspection.{class_name}"
+    assert is_dataclass(obj), f"eu5miner.inspection.{class_name} must remain a dataclass"
+    actual = tuple(f.name for f in fields(obj))
+    assert actual == expected_fields, (
+        f"Field shape of eu5miner.inspection.{class_name} changed.\n"
+        f"  expected: {expected_fields}\n"
+        f"  actual:   {actual}\n"
+        "Update GUI/MCP adapters, controllers, and serializers accordingly."
+    )
+
+
+# ----- End-to-end on a synthetic install --------------------------------------
+
+
+def test_inspect_install_against_synthetic_install(tmp_path: Path) -> None:
+    """``inspect_install`` on a fresh synthetic install returns a stable shape.
+
+    The GUI's ``DesktopController.initialize`` and the MCP's
+    ``inspect_install`` tool both call this function on first contact with an
+    install. If the shape changes, both consumers break simultaneously.
+    """
+    install_root = tmp_path / "install"
+    build_synthetic_install(install_root)
+
+    summary = inspection.inspect_install(install_root)
+
+    assert isinstance(summary, inspection.InstallSummary)
+    assert summary.root == install_root
+    assert summary.game_dir == install_root / "game"
+    assert summary.dlc_dir == install_root / "game" / "dlc"
+    assert summary.mod_dir == install_root / "game" / "mod"
+    # All three content phases must be present, in stable order.
+    assert tuple(p.phase for p in summary.phase_roots) == tuple(inspection.ContentPhase)
+    # A bare synthetic install has only the vanilla source.
+    assert [s.name for s in summary.sources] == ["vanilla"]
+
+
+def test_format_install_summary_renders_synthetic_install(tmp_path: Path) -> None:
+    """``format_install_summary`` must produce a non-empty human-readable block.
+
+    The GUI's status bar and the MCP's ``inspect_install`` tool response both
+    render this string. A regression here surfaces as a blank status bar
+    or empty tool output.
+    """
+    install_root = tmp_path / "install"
+    build_synthetic_install(install_root)
+
+    formatted = inspection.format_install_summary(inspection.inspect_install(install_root))
+
+    assert "Install root:" in formatted
+    assert str(install_root) in formatted
+    assert "Sources:" in formatted
+    assert "vanilla" in formatted
+
+
+def test_list_supported_systems_includes_core_systems() -> None:
+    """The supported-systems list must always include these core names.
+
+    The GUI's sidebar and the MCP's ``list_systems`` tool both render this
+    list. Removing or renaming any of these is a breaking change.
+    """
+    names = {info.name for info in inspection.list_supported_systems()}
+    required = {"economy", "diplomacy", "government", "religion", "interface", "map"}
+    missing = required - names
+    assert not missing, f"Missing required systems from list_supported_systems: {missing}"
+
+
+def test_list_entity_systems_includes_core_systems() -> None:
+    """The entity-systems list must always include these core names.
+
+    The GUI's entity browser and the MCP's ``list_entity_systems`` tool both
+    depend on these names.
+    """
+    names = {info.name for info in inspection.list_entity_systems()}
+    required = {"economy", "diplomacy", "government", "religion", "map"}
+    missing = required - names
+    assert not missing, f"Missing required entity systems: {missing}"
+
+
+# ----- Type-stability check ---------------------------------------------------
+
+
+def test_entity_field_browse_value_alias() -> None:
+    """``BrowseValue`` (the union alias for EntityField.value) must keep its members.
+
+    The GUI's report page and the MCP's ``get_entity`` serializer both render
+    these values. Adding a new type is fine; removing an existing one breaks
+    any saved browse value.
+    """
+    hints = get_type_hints(inspection.EntityField)
+    # The type is an alias; we just want to make sure the field exists and
+    # the annotation round-trips through get_type_hints without exploding.
+    assert "value" in hints
+
+
+# ----- Cache invalidation hook ------------------------------------------------
+
+
+def test_invalidate_system_entity_cache_is_idempotent(tmp_path: Path) -> None:
+    """``invalidate_system_entity_cache`` must accept a fresh install + system.
+
+    Both consumers call this defensively after writing mod updates. A
+    regression that raises on a missing cache entry would crash the GUI on
+    every mod apply and the MCP on every ``apply_mod_update`` tool call.
+    """
+    install_root = tmp_path / "install"
+    build_synthetic_install(install_root)
+    # Should not raise even though the system has never been queried.
+    inspection.invalidate_system_entity_cache(install_root, "religion")


### PR DESCRIPTION
## Summary

Expose the synthetic-install helpers previously hidden in `tests/integration_support.py` as a first-class public testing module, `eu5miner.testing`, so the GUI and MCP test suites can build and exercise the same synthetic install shape the library itself uses for inspection contract validation.

## What this PR does

- Promotes the synthetic-install builder, synthetic CLI smoke surface, and synthetic mod workflow surface to `src/eu5miner/testing.py` (new public module).
- Re-points `tests/integration_support.py` at the new module so internal library tests keep working with no behavioral change.
- Adds `tests/test_inspection_contract.py` (17 tests) pinning the shape of every public dataclass in the inspection facade: `SystemInfo`, `SystemReport`, `EntitySummary`, `EntityDetail`, `EntityReference`, `EntityField`, `EntitySystemInfo`, `InstallSummary`, `InstallPhaseRoot`, `InstallSourceSummary`.

All tests run without a real EU5 install, so they are safe in hosted CI.

## Why

Companion to the GUI ([Vality/EU5MinerGUI](https://github.com/Vality/EU5MinerGUI)) and MCP ([Vality/EU5MinerMCP](https://github.com/Vality/EU5MinerMCP)) consumer PRs. This is the library half of a cross-package integration test suite that catches the kind of breakage that hits when the library refactors its facade and the GUI/MCP silently follow the old shape through a private import.

## Test plan

- [x] `pytest tests/test_inspection_contract.py` — 17 passed
- [x] `pytest` (full library suite) — 215 passed, 127 skipped
- [x] `ruff check .` — clean

## Backwards compatibility

- New public module, no breaking changes
- `tests/integration_support.py` re-exports from `eu5miner.testing` — internal callers unaffected