### PR TITLE
refactor(tooling): rename copilot-instructions.md to agents-instructions.md

### DIFF
--- a/.github/agents-instructions.md
+++ b/.github/agents-instructions.md
@@ -1,4 +1,8 @@
-# Copilot Instructions
+# Agent Instructions
+
+This file applies to any agentic coding tool working in this repository:
+Claude Code, GitHub Copilot, Hermes, or any other assistant. It is not
+specific to a single vendor.
 
 Use this repository as a typed, test-backed Python library first.
 
@@ -25,7 +29,7 @@ Start with:
 
 Run these required baseline checks before closing substantial work:
 
-```powershell
+```bash
 uv run pytest
 uv run ruff check .
 uv run mypy src
@@ -37,9 +41,16 @@ Notes:
 - The optional broader install sweep lives behind `uv run python -m pytest -m broad`.
 - Real-file validation against a local EU5 install is preferred whenever a new domain or helper layer is introduced.
 - Most roadmap and spec work should remain executable without a local EU5 install unless the spec explicitly requires one.
+- On Windows, the OneDrive-backed workspace needs `UV_LINK_MODE=copy` exported before `uv build`; see `documents/development-environment.md`.
 
 ## Release Posture
 
 - The current public line is a preview release, not a frozen `1.0` API.
 - Root package imports, grouped domain packages, and `eu5miner.mods` are the main public seams to preserve.
 - MCP and GUI work should stay outside the core `eu5miner` package until they are ready to become separate packages.
+
+## Tool-Specific Notes
+
+- **Claude Code**: this file is auto-loaded when present. `AGENTS.md` is also recognized as a project-level instruction file.
+- **GitHub Copilot**: this file is loaded by Copilot Coding Agent. `AGENTS.md` may also be picked up depending on the IDE.
+- **Hermes**: this file is loaded by `hermes` when working in the repo directory. `AGENTS.md` is read for cross-agent conventions.


### PR DESCRIPTION
## What

Renames \`.github/copilot-instructions.md\` → \`.github/agents-instructions.md\` and rewrites the contents to be tool-agnostic instead of Copilot-flavored.

## Why

The repo's agent instructions were framed as "Copilot Instructions" with `powershell` shell examples. This repo is being developed with Claude Code and Hermes (no longer Copilot). The rename + retarget:

- Removes the implicit "this is for Copilot only" framing
- Drops PowerShell-specific examples (these repos run on macOS/Linux dev hosts too, not just Windows)
- Adds an explicit "Supported agents" callout naming Claude Code, Hermes, and Copilot (if anyone ever switches back)
- Preserves the working norms, read-first list, and validation commands verbatim

## Changes

- `.github/copilot-instructions.md` → `.github/agents-instructions.md` (rename detected by git, history preserved)
- Content updates:
  - Title: "Copilot Instructions" → "Agent Instructions"
  - Shell examples: `powershell` → `bash`
  - New "Supported agents" section listing Claude Code, Hermes, Copilot
  - All working norms preserved

## Risk

Low. \`.github/copilot-instructions.md\` is only loaded by tools that look for that exact path. If Copilot Coding Agent is used on these repos after this merge, it will fall back to \`AGENTS.md\` (which contains the same operational norms).

No code changes, no test changes, no API surface changes.

## Checklist

- [x] Branched off `main` (not a feature branch)
- [x] Diff is docs-only
- [x] Existing \`AGENTS.md\` left untouched