### PR TITLE
chore(release): 0.6.1 — add eu5miner.testing module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 0.6.1 - 2026-06-23
+
+- Added a public `eu5miner.testing` module exposing `build_synthetic_install` and related synthetic-install helpers so downstream consumer packages (`eu5miner-gui`, `eu5miner-mcp`) can run their cross-package contract tests against a deterministic in-memory install layout without a real EU5 install.
+
 ## Unreleased
 
-No unreleased changes recorded after `0.6.0`.
+No unreleased changes recorded after `0.6.1`.
 
 ## 0.6.0 - 2026-04-06
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "eu5miner"
-version = "0.6.0"
+version = "0.6.1"
 description = "Text-first parsing and modding support library for Europa Universalis V data files"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## What

Prepares a `v0.6.1` patch release that ships the `eu5miner.testing` module (added in #20) as a tagged artifact, so that downstream consumer packages (`eu5miner-gui`, `eu5miner-mcp`) can pin to a tagged version that includes the new public module.

## Why

`eu5miner-gui` and `eu5miner-mcp` both pin to `eu5miner @ git+https://github.com/Vality/EU5Miner.git@v0.6.0` in their `pyproject.toml`. The `eu5miner.testing` module was added in #20 *after* `v0.6.0` was tagged, so the pinned v0.6.0 install doesn't include it.

The downstream cross-package consumer tests (`tests/test_cross_package_consumer.py` in GUI and MCP) import `from eu5miner.testing import build_synthetic_install`, which fails at collection time on CI when the pinned v0.6.0 is installed:

```
ModuleNotFoundError: No module named 'eu5miner.testing'
```

This is breaking all 8 open Dependabot PRs across the GUI and MCP repos (`validate` job fails on test collection), even though the Dependabot bumps themselves are fine.

This release tags the current `main` as `v0.6.1` so the downstream packages can bump their pin to a version that actually contains `testing.py`.

## Changes

- `CHANGELOG.md`: add `## 0.6.1 - 2026-06-23` entry documenting the `eu5miner.testing` module.
- `pyproject.toml`: bump `version` from `0.6.0` to `0.6.1`.

No code changes — the `testing.py` module is already on `main` via #20.

## Followup PRs (separate)

- [ ] `eu5miner-gui`: bump `pyproject.toml` `eu5miner` pin from `v0.6.0` → `v0.6.1`
- [ ] `eu5miner-mcp`: bump `pyproject.toml` `eu5miner` pin from `v0.6.0` → `v0.6.1`

## Verification

Once this PR is merged and the tag is pushed:
1. The 8 currently-failing Dependabot PRs on GUI + MCP will pass CI
2. New `eu5miner.testing` module is reachable via the v0.6.1 tag

## Checklist

- [x] Branched off `main` (no code changes)
- [x] No code changes — version bump only
- [x] CHANGELOG entry added